### PR TITLE
write_receptor_config on_commit

### DIFF
--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -423,7 +423,7 @@ def on_instance_saved(sender, instance, created=False, raw=False, **kwargs):
     if settings.IS_K8S and created and instance.node_type == 'execution':
         from awx.main.tasks.receptor import write_receptor_config  # prevents circular import
 
-        write_receptor_config.apply_async(queue='tower_broadcast_all')
+        connection.on_commit(lambda: write_receptor_config.apply_async(queue='tower_broadcast_all'))
 
     if created or instance.has_policy_changes():
         schedule_policy_task()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
write_receptor_config needs to be called in an `on_commit` to that it will write the file after instance is saved to the db.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API